### PR TITLE
修正「油松」， 修正「盪」、「蕩」

### DIFF
--- a/luna_pinyin.dict/luna_pinyin.extended.dict.yaml
+++ b/luna_pinyin.dict/luna_pinyin.extended.dict.yaml
@@ -35,7 +35,7 @@
 
 ---
 name: luna_pinyin.extended
-version: "2019.07.05"
+version: "2021.05.17"
 sort: by_weight
 use_preset_vocabulary: true
 #此處爲明月拼音擴充詞庫（基本）默認鏈接載入的詞庫，有朙月拼音官方詞庫、明月拼音擴充詞庫（漢語大詞典）、明月拼音擴充詞庫（詩詞）、明月拼音擴充詞庫（含西文的詞彙）。如果不需要加載某个詞庫請將其用「#」註釋掉。
@@ -128817,7 +128817,7 @@ import_tables:
 海洋拉娜	hai yang la na	1
 海洋板塊	hai yang ban kuai	1
 海王紀	hai wang ji	1
-海產粥	hai xian zhou	1
+海產粥	hai chan zhou	1
 海芽湯	hai ya tang	1
 海芽蛋花湯	hai ya dan hua tang	1
 海芽豆腐湯	hai ya dou fu tang	1

--- a/luna_pinyin.dict/luna_pinyin.extended.dict.yaml
+++ b/luna_pinyin.dict/luna_pinyin.extended.dict.yaml
@@ -35,7 +35,7 @@
 
 ---
 name: luna_pinyin.extended
-version: "2015.12.02"
+version: "2019.07.05"
 sort: by_weight
 use_preset_vocabulary: true
 #此處爲明月拼音擴充詞庫（基本）默認鏈接載入的詞庫，有朙月拼音官方詞庫、明月拼音擴充詞庫（漢語大詞典）、明月拼音擴充詞庫（詩詞）、明月拼音擴充詞庫（含西文的詞彙）。如果不需要加載某个詞庫請將其用「#」註釋掉。
@@ -72621,7 +72621,6 @@ import_tables:
 游牧		7
 游牧民族		2
 游玩		1
-游盪		1
 游移		4
 游竣翔		1
 游船		1
@@ -81840,10 +81839,7 @@ import_tables:
 盧靚		1
 盧靜		1
 盧頌之		1
-盪婦		1
-盪平		1
 盪着		1
-盪秋千		1
 目光敏銳		1
 目光銳利		1
 目前在		1
@@ -105294,7 +105290,6 @@ import_tables:
 跆拳道館		1
 跋涉者		1
 跋陀羅		1
-跌盪		1
 跌穿		1
 跌聲		1
 跌落至		1
@@ -107175,7 +107170,6 @@ import_tables:
 迴力鏢		1
 迴因		1
 迴溪		1
-迴腸盪氣		1
 迴蕩		1
 迴診		8
 迴轉式壓縮機廠		1
@@ -127732,7 +127726,7 @@ import_tables:
 捷運局長	jie yun ju zhang	1
 掀戰火	xian zhan huo	1
 掀蓋	xian gai	1
-掃盪	sao dang	1
+掃蕩	sao dang	1
 授權給	shou quan gei	1
 掉漆	diao qi	1
 掏心挖肺	tao xin wa fei	1
@@ -128810,7 +128804,7 @@ import_tables:
 浮泛流濫	fu fan liu lan	1
 浮洲橋	fu zhou qiao	1
 浮浮沈沈	fu fu chen chen	1
-浮盪	fu dang	1
+浮蕩	fu dang	1
 海事職業	hai shi zhi ye	1
 海倫仙度絲	hai lun xian du si	1
 海噱	hai xue	1
@@ -129492,7 +129486,7 @@ import_tables:
 盤古樂隊	pan gu yue dui	1
 盤谷銀行	pan gu yin hang	1
 盧彥勳	lu yan xun	1
-盪氣迴腸	dang qi hui chang	1
+蕩氣迴腸	dang qi hui chang	1
 直排輪鞋	zhi pai lun xie	1
 直着	zhi zhuo	1
 直覺化	zhi jue hua	1
@@ -129728,7 +129722,7 @@ import_tables:
 空屋數	kong wu shu	1
 空氣槍	kong qi qiang	1
 空白帶	kong bai dai	1
-空空盪盪	kong kong dang dang	1
+空空蕩蕩	kong kong dang dang	1
 空色造雲罐	kong se zao yun guan	1
 空谷跫音	kong gu qiong yin	1
 空軍機械	kong jun ji xie	1
@@ -131293,7 +131287,7 @@ import_tables:
 遊戲噗	you xi pu	1
 遊戲界	you xi jie	1
 遊樂設施	you le she shi	1
-遊盪	you dang	1
+遊蕩	you dang	1
 運作得	yun zuo de	1
 運動區	yun dong qu	1
 運動家隊	yun dong jia dui	1
@@ -131614,7 +131608,7 @@ import_tables:
 開開心心地	kai kai xin xin de	1
 開陽白菜	kai yang bai cai	1
 閒來沒事	xian lai mei shi	1
-閒盪	xian dang	1
+閒蕩	xian dang	1
 閱讀者	yue du zhe	1
 闇之盾	an zhi dun	1
 闊葉樹林	kuo ye shu lin	1
@@ -131976,7 +131970,7 @@ import_tables:
 風雨中的寧靜	feng yu zhong de ning jing	1
 風魔小太郎	feng mo xiao tai lang	1
 風魔小次郎	feng mo xiao ci lang	1
-飄盪	piao dang	2
+飄蕩	piao dang	2
 飛一樣	fei yi yang	1
 飛不上去	fei bu shang qu	1
 飛信	fei xin	1

--- a/luna_pinyin.dict/luna_pinyin.hanyu.dict.yaml
+++ b/luna_pinyin.dict/luna_pinyin.hanyu.dict.yaml
@@ -73916,7 +73916,6 @@ use_preset_vocabulary: true
 放甲
 放白鴿
 放皓
-放盪
 放眉
 放神
 放秋壟

--- a/luna_pinyin.dict/luna_pinyin.hanyu.dict.yaml
+++ b/luna_pinyin.dict/luna_pinyin.hanyu.dict.yaml
@@ -20,7 +20,7 @@
 
 ---
 name: luna_pinyin.hanyu
-version: "2013.11.01"
+version: "2019.07.05"
 sort: by_weight
 use_preset_vocabulary: true
 ...
@@ -98237,7 +98237,6 @@ use_preset_vocabulary: true
 油鑊
 油雲
 油頭滑面
-油鬆
 油麻團
 油鼎
 沺沺

--- a/luna_pinyin_ziam_tuan.dict/luna_pinyin.hanyu.dict.yaml
+++ b/luna_pinyin_ziam_tuan.dict/luna_pinyin.hanyu.dict.yaml
@@ -20,7 +20,7 @@
 
 ---
 name: luna_pinyin.hanyu
-version: "2014.09.03"
+version: "2019.07.05"
 sort: by_weight
 use_preset_vocabulary: true
 ...
@@ -98237,7 +98237,6 @@ use_preset_vocabulary: true
 油鑊
 油雲
 油頭滑面
-油鬆
 油麻團
 油鼎
 沺沺

--- a/luna_pinyin_ziam_tuan.dict/luna_pinyin.hanyu.dict.yaml
+++ b/luna_pinyin_ziam_tuan.dict/luna_pinyin.hanyu.dict.yaml
@@ -73916,7 +73916,6 @@ use_preset_vocabulary: true
 放甲
 放白鴿
 放皓
-放盪
 放眉
 放神
 放秋壟

--- a/luna_pinyin_ziam_tuan.dict/luna_pinyin_ziam_tuan.extended.dict.yaml
+++ b/luna_pinyin_ziam_tuan.dict/luna_pinyin_ziam_tuan.extended.dict.yaml
@@ -37,7 +37,7 @@
 
 ---
 name: luna_pinyin_ziam_tuan.extended
-version: "2015.12.02"
+version: "2019.07.05"
 sort: by_weight
 use_preset_vocabulary: true
 #此処爲明月拼音擴充詞庫（基本）默認鏈接載入的詞庫，有朙月拼音官方詞庫、明月拼音擴充詞庫（漢語大詞典）、明月拼音擴充詞庫（詩詞）。如果不需要加載某个詞庫請將其用「#」註釋掉。
@@ -72346,7 +72346,6 @@ import_tables:
 游牧		7
 游牧民族		2
 游玩		1
-游盪		1
 游移		4
 游竣翔		1
 游船		1
@@ -81511,10 +81510,7 @@ import_tables:
 盧靚		1
 盧靜		1
 盧頌之		1
-盪婦		1
-盪平		1
 盪着		1
-盪秋千		1
 目光敏銳		1
 目光銳利		1
 目前在		1
@@ -104857,7 +104853,6 @@ import_tables:
 跆拳道館		1
 跋涉者		1
 跋陀羅		1
-跌盪		1
 跌穿		1
 跌聲		1
 跌落至		1
@@ -106735,7 +106730,6 @@ import_tables:
 迴力鏢		1
 迴因		1
 迴溪		1
-迴腸盪氣		1
 迴蕩		1
 迴診		8
 迴轉式壓縮機廠		1
@@ -127200,7 +127194,7 @@ import_tables:
 捷運局長	zie yvn gv zhang	1
 掀戰火	hian zhan huo	1
 掀蓋	hian gai	1
-掃盪	sao dang	1
+掃蕩	sao dang	1
 授權給	shou kvan gei	1
 掉漆	diao ci	1
 掏心挖肺	tao sim wa fei	1
@@ -128277,7 +128271,7 @@ import_tables:
 浮泛流濫	fu fan liu lam	1
 浮洲橋	fu zhou kiao	1
 浮浮沈沈	fu fu chem chem	1
-浮盪	fu dang	1
+浮蕩	fu dang	1
 海事職業	hai shii zhii ye	1
 海倫仙度絲	hai lun sian du sii	1
 海噱	hai sve	1
@@ -128957,7 +128951,7 @@ import_tables:
 盤古樂隊	pan gu yve dui	1
 盤谷銀行	pan gu yin hang	1
 盧彥勳	lu yan hvn	1
-盪氣迴腸	dang ki hui chang	1
+蕩氣迴腸	dang ki hui chang	1
 直排輪鞋	zhii pai lun hie	1
 直着	zhii zhuo	1
 直覺化	zhii gve hua	1
@@ -129191,7 +129185,7 @@ import_tables:
 空屋數	kong wu shu	1
 空氣槍	kong ki ciang	1
 空白帶	kong bai dai	1
-空空盪盪	kong kong dang dang	1
+空空蕩蕩	kong kong dang dang	1
 空色造雲罐	kong se zao yvn guan	1
 空谷跫音	kong gu kiong yim	1
 空軍機械	kong gvn gi hie	1
@@ -130756,7 +130750,7 @@ import_tables:
 遊戲噗	you hi pu	1
 遊戲界	you hi gie	1
 遊樂設施	you le she shii	1
-遊盪	you dang	1
+遊蕩	you dang	1
 運作得	yvn zuo de	1
 運動區	yvn dong kv	1
 運動家隊	yvn dong gia dui	1
@@ -131076,7 +131070,7 @@ import_tables:
 開開心心地	kai kai sim sim de	1
 開陽白菜	kai yang bai cai	1
 閒來沒事	hian lai mei shii	1
-閒盪	hian dang	1
+閒蕩	hian dang	1
 閱讀者	yve du zhe	1
 闇之盾	am zhii dun	1
 闊葉樹林	kuo ye shu lim	1
@@ -131438,7 +131432,7 @@ import_tables:
 風雨中的寧靜	fong yv zhong de ning zing	1
 風魔小太郎	fong mo siao tai lang	1
 風魔小次郎	fong mo siao cii lang	1
-飄盪	piao dang	2
+飄蕩	piao dang	2
 飛一樣	fei yi yang	1
 飛不上去	fei bu shang kv	1
 飛信	fei sin	1


### PR DESCRIPTION
1.  修改`luna_pinyin.dict/luna_pinyin.hanyu.dict.yaml`及`luna_pinyin_ziam_tuan.dict/luna_pinyin.hanyu.dict.yaml`: 刪除「油鬆」。
「油鬆」應爲「油松」，【八股文】中已包含「油松」。

2.  修改`luna_pinyin.dict/luna_pinyin.hanyu.dict.yaml`及`luna_pinyin_ziam_tuan.dict/luna_pinyin.hanyu.dict.yaml`: 
刪除「放盪」。
「放盪」應爲「放蕩」，【八股文】中已包含「放蕩」。

3. 修改`luna_pinyin.dict/luna_pinyin.extended.dict.yaml`及`luna_pinyin_ziam_tuan.dict/luna_pinyin_ziam_tuan.extended.dict.yaml`: 
修正「盪」、「蕩」。
【八股文】中已包含「遊蕩」、「蕩婦」「蕩平」、「盪鞦韆」、「跌蕩」、「迴腸蕩氣」、「掃蕩」、「浮蕩」、「蕩氣迴腸」、「空空蕩蕩」、「閒蕩」、「飄蕩」。