### PR TITLE
Update luna_pinyin_ziam_tuan.dict.yaml

### DIFF
--- a/luna_pinyin_ziam_tuan.dict/luna_pinyin_ziam_tuan.dict.yaml
+++ b/luna_pinyin_ziam_tuan.dict/luna_pinyin_ziam_tuan.dict.yaml
@@ -39616,7 +39616,7 @@ use_preset_vocabulary: true
 𥎔	li
 𥎕	hv
 𥎖	mi
-𥎗	hv
+𥎗	sv
 𥎘	ruan
 𥎛	gui
 𥎜	rong
@@ -45524,7 +45524,7 @@ use_preset_vocabulary: true
 𨼑	cha
 𨼒	chan
 𨼓	zhii
-𨼔	hvm
+𨼔	sim
 𨼣	ge
 𨼤	chen
 𨼥	ge


### PR DESCRIPTION
「𥎗」與「𨼔」二字應是尖音 sü 和 sim。可能還存在其他類似問題