### PR TITLE
fix YAML grammar problem

### DIFF
--- a/luna_pinyin.dict/luna_pinyin.custom.yaml
+++ b/luna_pinyin.dict/luna_pinyin.custom.yaml
@@ -27,7 +27,7 @@
 
 patch:
   # 載入朙月拼音擴充詞庫
-  "translator/dictionary": luna_pinyin.extended
+  translator/dictionary: luna_pinyin.extended
   # 改寫拼寫運算，使得含西文的詞彙（位於 luna_pinyin.cn_en.dict.yaml 中）不影響簡拼功能（注意，此功能只適用於朙月拼音系列方案，不適用於各類雙拼方案）
   # 本條補靪只在「小狼毫 0.9.30」、「鼠鬚管 0.9.25 」、「Rime-1.2」及更高的版本中起作用。
-  "speller/algebra/@before 0": xform/^([b-df-hj-np-tv-z])$/$1_/
+  speller/algebra/@before 0: xform/^([b-df-hj-np-tv-z])$/$1_/


### PR DESCRIPTION
`translator/dictionary` - A key doesn't need quote signs.
Unless the dictionary just doesn't work properly.